### PR TITLE
ci(security): pin trivy-action to v0.36.0 SHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
           cache-to: type=gha,mode=max
           
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ fromJSON(steps.build.outputs.metadata)['image.name'] }}
           format: 'sarif'


### PR DESCRIPTION
Pin `aquasecurity/trivy-action` from `@master` to the v0.36.0 release SHA. `@master` means any push to that repo's main branch (including a hijack) runs in this workflow with the workflow's secrets. SHA pinning is the only way to lock that down.

Bumping the pin in the future is the right operation; tracking master is not.

@copilot please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)