### PR TITLE
chore(deps): update puma to 8.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "sprockets-rails"
 gem "sqlite3", "~> 2.9"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 7.2.1"
+gem "puma", "~> 8.0.2"
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (7.2.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -390,7 +390,7 @@ DEPENDENCIES
   jbuilder
   kamal
   memory_profiler
-  puma (~> 7.2.1)
+  puma (~> 8.0.2)
   rails (~> 8.1.2)
   redis (~> 5.4)
   rubocop


### PR DESCRIPTION
Replaces Dependabot PR #364's vulnerable Puma 8.0.1 target with the minimum patched 8.0.2 release. Puma's dependency set is unchanged; full Ruby 3.3 GitHub CI is required before merge.